### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "babel-polyfill": "^6.3.14",
     "bluebird": "^3.3.1",
     "faye-websocket": "^0.10.0",
-    "node-uuid": "^1.4.7",
     "ramda": "^0.19.1",
     "simple-statistics": "^1.0.1",
+    "uuid": "^3.0.0",
     "yargs": "^4.1.0"
   }
 }

--- a/src/get-asteroid/actions/call.js
+++ b/src/get-asteroid/actions/call.js
@@ -1,4 +1,4 @@
-import {v4} from "node-uuid";
+import {v4} from "uuid";
 
 import * as constants from "../../constants";
 

--- a/src/get-asteroid/actions/subscribe.js
+++ b/src/get-asteroid/actions/subscribe.js
@@ -1,4 +1,4 @@
-import {v4} from "node-uuid";
+import {v4} from "uuid";
 
 import * as constants from "../../constants";
 

--- a/src/run-measurement-scenarios.js
+++ b/src/run-measurement-scenarios.js
@@ -1,4 +1,4 @@
-import {v4} from "node-uuid";
+import {v4} from "uuid";
 import {range} from "ramda";
 
 import * as constants from "./constants";

--- a/src/run-stress-scenarios.js
+++ b/src/run-stress-scenarios.js
@@ -1,5 +1,5 @@
 import {map} from "bluebird";
-import {v4} from "node-uuid";
+import {v4} from "uuid";
 import {range} from "ramda";
 
 import * as constants from "./constants";


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.